### PR TITLE
Fix documentation for specifying github accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ After that, you can install the 'keyholes' for this user from Github. This
 means they will be able to get in without manually typing a password, just like
 when they `git push` to Github:
 
-    tweemux hubkey cirwin github: ConradIrwin
+    tweemux hubkey cirwin ConradIrwin
+    # where "cirwin" is the local user name and "ConradIrwin" is their github user name
     # or, if their Unix username is their Github username, there's a shorthand:
     tweemux hubkey rking
 


### PR DESCRIPTION
In the version of tweemux I have you do not need to specify `github:`.

I also added a line explaining what each user name maps to.
